### PR TITLE
update handleTimerReset method

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ const pomodoroChart = new Chart(el, {
 });
 ```
 
+# Version 0.4.6-beta
+
+`handleResetTimer()` now sets `timePassingMessage` and `taskCycleIndex` back to their default values.
+
 # Version 0.4.5-beta
 
 All methods on the Pomodoro Timer Plugin are now immutable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "pomodorotimerplugin",
-    "version": "0.4.5-beta",
+    "version": "0.4.6-beta",
     "description": "A ChartJS Plugin for turning a doughnut chart into a PomodoroTimer",
     "main": "index.js",
     "scripts": {

--- a/src/PomodoroTimerPlugin.js
+++ b/src/PomodoroTimerPlugin.js
@@ -182,7 +182,9 @@ const PomodoroTimerPlugin = {
             time: time,
             timeLeft: 0,
             minutes: minutes < 10 ? '0' + minutes : minutes,
-            seconds: (time % 60) < 10 ? '0' + time % 60 : time % 60
+            seconds: (time % 60) < 10 ? '0' + time % 60 : time % 60,
+            timePassingMessage: "Ready to Start",
+            taskCycleIndex: 0
         });
         this.stopTimer();
         chart.data.datasets[0].data = [0, time];
@@ -207,7 +209,6 @@ const PomodoroTimerPlugin = {
             this.privateVariables.set(this, {
                 ...this.privateVariables.get(this),
                 taskCycleIndex: 0,
-                timePassingMessage: "Ready to Start"
             })
             return;
         }


### PR DESCRIPTION
previously, resetting the timer was not resetting the `timePassingMessage` and `taskCycleIndex` back to their default values but now it does.